### PR TITLE
setup.cfg: constrain the jinja2 dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ docs =
     furo>=2020.11.19b18
     sphinx~=3.0
     sphinx-autodoc-typehints>=1.10.0
+    Jinja2<3.1  # https://github.com/readthedocs/readthedocs.org/issues/9038
 
 [flake8]
 max-line-length = 127


### PR DESCRIPTION
See https://github.com/readthedocs/readthedocs.org/issues/9038

Signed-off-by: Filipe Laíns <lains@riseup.net>