### PR TITLE
metadata: use utf-8 encoding when opening files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,16 +10,19 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - 'windows-latest'
+          - 'ubuntu-latest'
         python:
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
-          - '3.11-dev'
+          - '3.11'
 
     steps:
       - name: Checkout

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -363,7 +363,7 @@ class StandardMetadata():
                     f'License file not found (`{filename}`)',
                     key='project.license.file',
                 )
-            text = file.read_text()
+            text = file.read_text(encoding='utf-8')
 
         assert text is not None
         return License(text, file)
@@ -427,7 +427,7 @@ class StandardMetadata():
                     f'Readme file not found (`{filename}`)',
                     key='project.license.file',
                 )
-            text = file.read_text()
+            text = file.read_text(encoding='utf-8')
 
         assert text is not None
         return Readme(text, file, content_type)

--- a/tests/packages/full-metadata/README.md
+++ b/tests/packages/full-metadata/README.md
@@ -1,1 +1,1 @@
-some readme
+some readme 👋

--- a/tests/packages/full-metadata2/LICENSE
+++ b/tests/packages/full-metadata2/LICENSE
@@ -1,1 +1,1 @@
-Some license!
+Some license! 👋

--- a/tests/packages/full-metadata2/README.rst
+++ b/tests/packages/full-metadata2/README.rst
@@ -1,1 +1,1 @@
-some readme
+some readme 👋

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -497,7 +497,7 @@ def test_value(package):
     assert metadata.license.file is None
     assert metadata.license.text == 'some license text'
     assert metadata.readme.file == pathlib.Path('README.md')
-    assert metadata.readme.text == pathlib.Path('README.md').read_text()
+    assert metadata.readme.text == pathlib.Path('README.md').read_text(encoding='utf-8')
     assert metadata.readme.content_type == 'text/markdown'
     assert metadata.description == 'A package with all the metadata :)'
     assert metadata.authors == [
@@ -549,7 +549,7 @@ def test_read_license(package2):
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
 
     assert metadata.license.file == pathlib.Path('LICENSE')
-    assert metadata.license.text == 'Some license!\n'
+    assert metadata.license.text == 'Some license! 👋\n'
 
 
 @pytest.mark.parametrize(
@@ -614,7 +614,7 @@ def test_as_rfc822(package):
         ],
         'Description-Content-Type': ['text/markdown'],
     }
-    assert core_metadata.body == 'some readme\n'
+    assert core_metadata.body == 'some readme 👋\n'
 
 
 def test_as_rfc822_dynamic(package_dynamic_description):


### PR DESCRIPTION
Windows currently opens files with a potentially different encoding, meaning that if you put a unicode character in your readme it would fail to read the file.

closes #36