### PR TITLE
typing: fix issues with Python <3.7.2 and simplify

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ docs =
     Jinja2<3.1  # https://github.com/readthedocs/readthedocs.org/issues/9038
 
 [flake8]
-max-line-length = 127
+max-line-length = 129
 max-complexity = 10
 extend-ignore = E203
 


### PR DESCRIPTION
I recently saw this when trying to test scikit-build-core on conda, in preparation for conda-forge support:

```
    File "C:\Miniconda\envs\test\conda-bld\scikit_build_example_1669132774510\_build_env\lib\site-packages\pyproject_metadata\__init__.py", line 13, in <module>
      from typing import Any, DefaultDict, Dict, List, Mapping, Optional, OrderedDict, Tuple, Union
  ImportError: cannot import name 'OrderedDict' from 'typing' (C:\Miniconda\envs\test\conda-bld\scikit_build_example_1669132774510\_build_env\lib\typing.py)
  error: subprocess-exited-with-error
```

Checking, [it seems OrderedDict was added in 3.7.2](https://docs.python.org/3/library/typing.html#typing.OrderedDict). Better yet, just use non-deprecated `collections.OrderedDict` and utilize `from __future__ import annotations` to write modern code that also isn't broken on older Pythons. :)
