### PR TITLE
fix: metadata modified by printing msg

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections
+import copy
 import dataclasses
 import os
 import os.path
@@ -327,12 +328,11 @@ class StandardMetadata():
         extra: str,
         requirement: packaging.requirements.Requirement,
     ) -> packaging.requirements.Requirement:
-        if requirement.marker:  # append our extra to the marker
-            requirement.marker = packaging.markers.Marker(
-                str(requirement.marker) + f' and extra == "{extra}"'
-            )
-        else:  # add our extra marker
-            requirement.marker = packaging.markers.Marker(f'extra == "{extra}"')
+        # append or add our extra marker
+        requirement = copy.copy(requirement)
+        requirement.marker = packaging.markers.Marker(
+            f'{requirement.marker} and extra == "{extra}"' if requirement.marker else f'extra == "{extra}"',
+        )
         return requirement
 
     @staticmethod

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -484,9 +484,13 @@ def test_load(package, data, error):
         pyproject_metadata.StandardMetadata.from_pyproject(tomllib.loads(data))
 
 
-def test_value(package):
+@pytest.mark.parametrize('after_rfc', [False, True])
+def test_value(package, after_rfc):
     with open('pyproject.toml', 'rb') as f:
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
+
+    if after_rfc:
+        metadata.as_rfc822()
 
     assert metadata.dynamic == []
     assert metadata.name == 'full-metadata'


### PR DESCRIPTION
Making a msg modifies the metadata each time.

As a temporary workaround, `copy.deepcopy(metadata).as_rfc822()` can be used by user code.