### PR TITLE
ci: add all checks pass check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up target Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -44,7 +44,7 @@ jobs:
         shell: python
 
       - name: Set up Python for nox
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -64,3 +64,19 @@ jobs:
           flags: tests
           env_vars: PYTHON
           name: ${{ matrix.python }}
+
+
+  # https://github.com/marketplace/actions/alls-green#why
+  required-checks-pass: # This job does nothing and is only used for the branch protection
+    if: always()
+
+    needs:
+      - pytest
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
The required tests are broken due to changing the job names (win + ubuntu instead of one run each). This adds a single job that can be used to gate on, and then it will work in the future even if jobs changed (and old jobs won't all turn orange when things change, too). This needs to be updated in the branch protection (@FFY00). I've taken the naming from pypa/build.
