### PR TITLE
ruff: replace flake8 and isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,9 @@ repos:
   - id: double-quote-string-fixer
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: "v0.0.253"
   hooks:
-  - id: isort
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
-  hooks:
-  - id: flake8
-    language_version: python3.8
+  - id: ruff
+    args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,54 @@
 [build-system]
 requires = ['setuptools >= 42.0.0']
 build-backend = 'setuptools.build_meta'
+
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+xfail_strict = true
+filterwarnings = ["error"]
+log_cli_level = "info"
+testpaths = ["tests"]
+
+[tool.mypy]
+ignore_missing_imports = true
+strict = true
+
+
+[tool.ruff]
+select = [
+  "E", "F", "W", # flake8
+  "C90",         # mccabe
+  "B",           # flake8-bugbear
+  "I",           # isort
+  "ARG",         # flake8-unused-arguments
+  "C4",          # flake8-comprehensions
+  "ICN",         # flake8-import-conventions
+  "ISC",         # flake8-implicit-str-concat
+  "G",           # flake8-logging-format
+  "PGH",         # pygrep-hooks
+  "PIE",         # flake8-pie
+  "PL",          # pylint
+  "PT",          # flake8-pytest-style
+  "RET",         # flake8-return
+  "RUF",         # Ruff-specific
+  "SIM",         # flake8-simplify
+  "T20",         # flake8-print
+  "UP",          # pyupgrade
+  "YTT",         # flake8-2020
+  "EXE",         # flake8-executable
+  "NPY",         # NumPy specific rules
+  "PD",          # pandas-vet
+]
+extend-ignore = [
+  "PLR",    # Design related pylint codes
+  "E501",   # Line too long
+  "PT004",  # Use underscore for non-returning fixture (use usefixture instead)
+]
+isort.known-first-party = ["pyproject-metadata"]
+isort.lines-after-imports = 2
+isort.lines-between-types = 1
+line-length = 129
+mccabe.max-complexity = 10
+target-version = "py37"

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -449,7 +449,7 @@ class StandardMetadata():
                 raise ConfigurationError(
                     'Field "project.dependencies" contains an invalid PEP 508 '
                     f'requirement string "{req}" ("{str(e)}")'
-                )
+                ) from None
         return requirements
 
     @staticmethod
@@ -472,7 +472,7 @@ class StandardMetadata():
                     f'Field "project.optional-dependencies.{extra}" has an invalid type, expecting a '
                     f'dictionary PEP 508 requirement strings (got "{requirements}")'
                 )
-            for i, req in enumerate(requirements):
+            for req in requirements:
                 if not isinstance(req, str):
                     raise ConfigurationError(
                         f'Field "project.optional-dependencies.{extra}" has an invalid type, '
@@ -484,7 +484,7 @@ class StandardMetadata():
                     raise ConfigurationError(
                         f'Field "project.optional-dependencies.{extra}" contains '
                         f'an invalid PEP 508 requirement string "{req}" ("{str(e)}")'
-                    )
+                    ) from None
         return dict(requirements_dict)
 
     @staticmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,20 +43,5 @@ docs =
     sphinx-autodoc-typehints>=1.10.0
     Jinja2<3.1  # https://github.com/readthedocs/readthedocs.org/issues/9038
 
-[flake8]
-max-line-length = 129
-max-complexity = 10
-extend-ignore = E203
-
-[mypy]
-ignore_missing_imports = True
-strict = True
-
-[isort]
-line_length = 127
-lines_between_types = 1
-lines_after_imports = 2
-known_first_party = pyproject-metadata
-
 [coverage:html]
 show_contexts = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,19 +21,19 @@ def cd_package(package):
         os.chdir(cur_dir)
 
 
-@pytest.fixture
+@pytest.fixture()
 def package():
     with cd_package('full-metadata') as new_path:
         yield new_path
 
 
-@pytest.fixture
+@pytest.fixture()
 def package2():
     with cd_package('full-metadata2') as new_path:
         yield new_path
 
 
-@pytest.fixture
+@pytest.fixture()
 def package_dynamic_description():
     with cd_package('dynamic-description') as new_path:
         yield new_path

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -479,13 +479,15 @@ from .conftest import cd_package
         ),
     ]
 )
-def test_load(package, data, error):
+@pytest.mark.usefixtures('package')
+def test_load(data, error):
     with pytest.raises(pyproject_metadata.ConfigurationError, match=re.escape(error)):
         pyproject_metadata.StandardMetadata.from_pyproject(tomllib.loads(data))
 
 
 @pytest.mark.parametrize('after_rfc', [False, True])
-def test_value(package, after_rfc):
+@pytest.mark.usefixtures('package')
+def test_value(after_rfc):
     with open('pyproject.toml', 'rb') as f:
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
 
@@ -546,7 +548,8 @@ def test_value(package, after_rfc):
     ]
 
 
-def test_read_license(package2):
+@pytest.mark.usefixtures('package2')
+def test_read_license():
     with open('pyproject.toml', 'rb') as f:
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
 
@@ -576,7 +579,8 @@ def test_readme_content_type_unknown():
         pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
 
 
-def test_as_rfc822(package):
+@pytest.mark.usefixtures('package')
+def test_as_rfc822():
     with open('pyproject.toml', 'rb') as f:
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
     core_metadata = metadata.as_rfc822()
@@ -619,7 +623,8 @@ def test_as_rfc822(package):
     assert core_metadata.body == 'some readme 👋\n'
 
 
-def test_as_rfc822_dynamic(package_dynamic_description):
+@pytest.mark.usefixtures('package_dynamic_description')
+def test_as_rfc822_dynamic():
     with open('pyproject.toml', 'rb') as f:
         metadata = pyproject_metadata.StandardMetadata.from_pyproject(tomllib.load(f))
     core_metadata = metadata.as_rfc822()


### PR DESCRIPTION
Move to using Ruff. Adding some standard pytest config too, since I misspelled a marker and it let it through.