### PR TITLE
fix: use comma to separate keywords

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -274,7 +274,7 @@ class StandardMetadata():
         # skip 'Supported-Platform'
         if self.description:
             message['Summary'] = self.description
-        message['Keywords'] = ' '.join(self.keywords)
+        message['Keywords'] = ','.join(self.keywords)
         if 'homepage' in self.urls:
             message['Home-page'] = self.urls['homepage']
         # skip 'Download-URL'

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -589,7 +589,7 @@ def test_as_rfc822():
         'Name': ['full-metadata'],
         'Summary': ['A package with all the metadata :)'],
         'Version': ['3.2.1'],
-        'Keywords': ['trampolim is interesting'],
+        'Keywords': ['trampolim,is,interesting'],
         'Home-page': ['example.com'],
         'Author': ['Example!'],
         'Author-Email': ['Unknown <example@example.com>'],


### PR DESCRIPTION
The core metadata specification link: https://packaging.python.org/en/latest/specifications/core-metadata/#id14