### PR TITLE
fix: preserve user specified name in metadata

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -8,7 +8,6 @@ import dataclasses
 import os
 import os.path
 import pathlib
-import re
 import typing
 
 from collections.abc import Mapping
@@ -17,6 +16,7 @@ from typing import Any
 import packaging.markers
 import packaging.requirements
 import packaging.specifiers
+import packaging.utils
 import packaging.version
 
 
@@ -195,8 +195,11 @@ class StandardMetadata:
     dynamic: list[str] = dataclasses.field(default_factory=list)
 
     def __post_init__(self) -> None:
-        self.name = re.sub(r'[-_.]+', '-', self.name).lower()
         self._update_dynamic(self.version)
+
+    @property
+    def canonnical_name(self) -> str:
+        return packaging.utils.canonicalize_name(self.name)
 
     @classmethod
     def from_pyproject(

--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -198,7 +198,7 @@ class StandardMetadata:
         self._update_dynamic(self.version)
 
     @property
-    def canonnical_name(self) -> str:
+    def canonical_name(self) -> str:
         return packaging.utils.canonicalize_name(self.name)
 
     @classmethod

--- a/tests/packages/full-metadata/pyproject.toml
+++ b/tests/packages/full-metadata/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = 'full-metadata'
+name = 'full_metadata'
 version = '3.2.1'
 description = 'A package with all the metadata :)'
 readme = 'README.md'

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -504,7 +504,8 @@ def test_value(after_rfc):
         metadata.as_rfc822()
 
     assert metadata.dynamic == []
-    assert metadata.name == 'full-metadata'
+    assert metadata.name == 'full_metadata'
+    assert metadata.canonical_name == 'full-metadata'
     assert metadata.version == packaging.version.Version('3.2.1')
     assert metadata.requires_python == packaging.specifiers.Specifier('>=3.8')
     assert metadata.license.file is None
@@ -595,7 +596,7 @@ def test_as_rfc822():
     core_metadata = metadata.as_rfc822()
     assert core_metadata.headers == {
         'Metadata-Version': ['2.1'],
-        'Name': ['full-metadata'],
+        'Name': ['full_metadata'],
         'Summary': ['A package with all the metadata :)'],
         'Version': ['3.2.1'],
         'Keywords': ['trampolim,is,interesting'],


### PR DESCRIPTION
This is a proposed fix for https://github.com/FFY00/python-pyproject-metadata/issues/60. I've preserved the original name and provided a property to get the canonical name too (is this a good idea? Or just document `packaging.utils.canonicalize_name`?).

What do you think?
