### PR TITLE
allow dynamic version

### DIFF
--- a/pyproject_metadata/__init__.py
+++ b/pyproject_metadata/__init__.py
@@ -266,10 +266,11 @@ class StandardMetadata:
 
     def write_to_rfc822(self, message: RFC822Message) -> None:  # noqa: C901
         message['Metadata-Version'] = '2.2' if self.dynamic else '2.1'
+        if 'name' in self.dynamic:
+            raise ConfigurationError('Name cannot be dynamic')
         message['Name'] = self.name
-        if not self.version:
-            raise ConfigurationError('Missing version field')
-        message['Version'] = str(self.version)
+        if self.version:
+            message['Version'] = str(self.version)
         # skip 'Platform'
         # skip 'Supported-Platform'
         if self.description:
@@ -305,8 +306,6 @@ class StandardMetadata:
             message.body = self.readme.text
         # Core Metadata 2.2
         for field in self.dynamic:
-            if field in ('name', 'version'):
-                raise ConfigurationError(f'Field cannot be dynamic: {field}')
             message['Dynamic'] = field
 
     def _name_list(self, people: list[tuple[str, str]]) -> str:

--- a/tests/test_standard_metadata.py
+++ b/tests/test_standard_metadata.py
@@ -642,16 +642,7 @@ def test_as_rfc822_invalid_dynamic():
         version=packaging.version.Version('1.0.0'),
     )
     metadata.dynamic = ['name']
-    with pytest.raises(pyproject_metadata.ConfigurationError, match='Field cannot be dynamic: name'):
-        metadata.as_rfc822()
-    metadata.dynamic = ['version']
-    with pytest.raises(pyproject_metadata.ConfigurationError, match='Field cannot be dynamic: version'):
-        metadata.as_rfc822()
-
-
-def test_as_rfc822_missing_version():
-    metadata = pyproject_metadata.StandardMetadata(name='something')
-    with pytest.raises(pyproject_metadata.ConfigurationError, match='Missing version field'):
+    with pytest.raises(pyproject_metadata.ConfigurationError, match='Name cannot be dynamic'):
         metadata.as_rfc822()
 
 


### PR DESCRIPTION
Name is the only field than cannot be dynamic: https://peps.python.org/pep-0621/#name