### PR TITLE
ci: fix readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,9 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "furo>=2020.11.19b18",
-    "Jinja2<3.1",  # https://github.com/readthedocs/readthedocs.org/issues/9038
+    "furo>=2023.9.10",
     "sphinx-autodoc-typehints>=1.10.0",
-    "sphinx~=3.0",
+    "sphinx~=7.0",
 ]
 test = [
     "pytest-cov[toml]>=2",


### PR DESCRIPTION
RtD requires the build: os: table now, as promised for a few months. Can be seen via:

https://learn.scientific-python.org/development/guides/repo-review/?repo=FFY00/python-pyproject-metadata&branch=main
