### PR TITLE
fix: cleaner tracebacks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           import platform; import os; import sys; import codecs
           base = '.'.join(map(str, sys.version_info[:2]))
-          env = 'BASE={}\n'.format(base)
-          print('Picked:\n{}for{}'.format(env, sys.version))
+          env = f'BASE={base}\n'
+          print(f'Picked:\n{env}for{sys.version}')
           with codecs.open(os.environ['GITHUB_ENV'], 'a', 'utf-8') as file_handler:
                file_handler.write(env)
         shell: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,6 @@ pylint.max-branches = 15
 
 [tool.coverage]
 html.show_contexts = true
+report.exclude_also = [
+    "if TYPE_CHECKING:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ extend-select = [
   "C4",          # flake8-comprehensions
   "ICN",         # flake8-import-conventions
   "ISC",         # flake8-implicit-str-concat
+  "EM",          # flake8-errmsg
   "G",           # flake8-logging-format
   "PGH",         # pygrep-hooks
   "PIE",         # flake8-pie

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,5 +94,5 @@ pylint.max-branches = 15
 [tool.coverage]
 html.show_contexts = true
 report.exclude_also = [
-    "if TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:",
 ]


### PR DESCRIPTION
This makes the tracebacks cleaner by not repeating the error message. And it also clarifies that `key=` isn't affecting the `{key}` field in many of the strings.

Also was doing some cleanup related to line length (using fully qualified types in type expressions makes them too long, so fixing one of them).
